### PR TITLE
Added relative paths for esmf.mk and src [skip appveyor]

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-export ESMFMKFILE=$(find ${PREFIX} -name '*esmf.mk')
+export ESMFMKFILE=${PREFIX}/lib/esmf.mk
 
-ESMPY_SRC=$(find . -name '*ESMPy*')
+ESMPY_SRC=${SRC_DIR}/src/addon/ESMPy
 cd ${ESMPY_SRC}
+
 
 ${PYTHON} setup.py build --ESMFMKFILE=${ESMFMKFILE}
 ${PYTHON} setup.py install --record record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ source:
     git_tag: ESMF_7_0_0
 
 build:
-    number: 0
+    number: 1
     skip: True # [win or py3k]
 
 requirements:


### PR DESCRIPTION
The ``esmpy`` builds were breaking with the changes in the ``esmf`` build paths. This adds better relative paths.

@ocefpaf, the same issue is occurring the IOOS channel. Do I need to do another PR there?