### PR TITLE
Drop r

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: linux_64
+- job: linux
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 240
@@ -35,3 +35,5 @@ jobs:
 
   - script: .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: osx_64
+- job: osx
   pool:
     vmImage: macOS-10.13
   timeoutInMinutes: 240
@@ -87,4 +87,6 @@ jobs:
       set -x -e
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Upload recipe
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "7.1.0" %}
-{% set ver = version.replace(".", "_") %}
+{% set ver = version.replace(".", "_") + "r" %}
 
 package:
   name: esmpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.1.0r" %}
+{% set version = "7.1.0" %}
 {% set ver = version.replace(".", "_") %}
 
 package:
@@ -11,7 +11,7 @@ source:
 
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Closes https://github.com/conda-forge/esmpy-feedstock/issues/21

@bekozi this is the same as https://github.com/conda-forge/esmf-feedstock/pull/36

What do you want us to do:

- close this and pull the binaries from https://github.com/conda-forge/esmf-feedstock/pull/36, or
- merge this and drop the `r` in the version?